### PR TITLE
Handling hidden jobs via the API

### DIFF
--- a/app/api/get_job/route.ts
+++ b/app/api/get_job/route.ts
@@ -8,9 +8,18 @@ export async function GET(request: NextRequest) {
     // Validate that the parameter is a valid number and within the range of available job IDs
     if (!isNaN(job_id) && job_id > 0 && job_id <= jobsJson.length) {
         const job = jobsJson.filter((job) => job.id === job_id);
-        return new Response(JSON.stringify(job), {
-            headers: { 'Content-Type': 'application/json' },
-        });
+        if (!job[0].hidden) {
+            return new Response(JSON.stringify(job), {
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }
+        else {
+            // Return an error response if validation fails
+            return new Response(JSON.stringify({ error: "Invalid job ID" }), {
+                status: 400, // Bad Request
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }
     } else {
         // Return an error response if validation fails
         return new Response(JSON.stringify({ error: "Invalid job ID" }), {


### PR DESCRIPTION
Added a check so jobs marked as `hidden` will not be returned via the `get_job` api.